### PR TITLE
Add iPad retina 144x144 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FaviconMaker [![Build Status](https://secure.travis-ci.org/follmann/favicon_maker.png)](http://travis-ci.org/[follmann]/[favicon_maker])
 ============
 
-Tired of creating a gazillion different favicons to satisfy all kinds of devices and resolutions in different file formats? 
+Tired of creating a gazillion different favicons to satisfy all kinds of devices and resolutions in different file formats?
 
 I know I was, so I created FaviconMaker to ease the tedious process of creating multiple versions of your favicon.
 
@@ -47,13 +47,13 @@ In order to integrate the FaviconMaker effortless into your [Middleman](https://
 ### Simple
     require "rubygems"
     require "favicon_maker"
-    
+
     FaviconMaker::Generator.create_versions
 
 Uses the following defaults:
 
     options = {
-      :versions => [:apple_114, :apple_72, :apple_57, :apple_pre, :apple, :fav_png, :fav_ico],
+      :versions => [:apple_144, :apple_114, :apple_72, :apple_57, :apple_pre, :apple, :fav_png, :fav_ico],
       :custom_versions => {},
       :root_dir => File.dirname(__FILE__),
       :input_dir => "favicons",
@@ -62,11 +62,11 @@ Uses the following defaults:
       :copy => false
     }
 
-### Advanced 
+### Advanced
 (untested attempted Rails integration, using all available options. Could be used in a Rake task or Capistrano recipe)
 
     options = {
-      :versions => [:apple_114, :apple_57, :apple, :fav_png, :fav_ico],
+      :versions => [:apple_144, :apple_114, :apple_57, :apple, :fav_png, :fav_ico],
       :custom_versions => {:apple_extreme_retina => {:filename => "apple-touch-icon-228x228-precomposed.png", :dimensions => "228x228", :format => "png"}},
       :root_dir => Rails.root,
       :input_dir => File.join("app", "assets", "public"),
@@ -74,11 +74,11 @@ Uses the following defaults:
       :output_dir => "public",
       :copy => true
     }
-    
+
     FaviconMaker::Generator.create_versions(options) do |filepath|
       puts "Created favicon: #{filepath}"
     end
-    
+
 ## Base Image Guideline
 Choose the version with the biggest dimension as your base image. Currently the size 114x114 for newer iOS devices marks the upper limit. So just create a PNG with 24 or 32 Bit color depth and 114x114 document size. Downscaling of images always works better than upscaling.
 

--- a/lib/favicon_maker/generator.rb
+++ b/lib/favicon_maker/generator.rb
@@ -1,10 +1,11 @@
 module FaviconMaker
   require "mini_magick"
   require 'fileutils'
-  
+
   class Generator
-    
+
     ICON_VERSIONS = {
+      :apple_144 => {:filename => "apple-touch-icon-144x144-precomposed.png", :dimensions => "144x144", :format => "png"},
       :apple_114 => {:filename => "apple-touch-icon-114x114-precomposed.png", :dimensions => "114x114", :format => "png"},
       :apple_72 => {:filename => "apple-touch-icon-72x72-precomposed.png", :dimensions => "72x72", :format => "png"},
       :apple_57 => {:filename => "apple-touch-icon-57x57-precomposed.png", :dimensions => "57x57", :format => "png"},
@@ -13,9 +14,9 @@ module FaviconMaker
       :fav_png => {:filename => "favicon.png", :dimensions => "16x16", :format => "png"},
       :fav_ico => {:filename => "favicon.ico", :dimensions => "16x16", :format => "ico"}
     }
-    
+
     class << self
-    
+
       def create_versions(options={}, &block)
         options = {
           :versions => ICON_VERSIONS.keys,
@@ -26,17 +27,17 @@ module FaviconMaker
           :output_dir => "favicons_output",
           :copy => false
         }.merge(options)
-      
+
         raise ArgumentError unless options[:versions].is_a? Array
         base_path = File.join(options[:root_dir], options[:input_dir])
         input_path = File.join(base_path, options[:base_image])
-        
+
         icon_versions = ICON_VERSIONS.merge(options[:custom_versions])
         (options[:versions] + options[:custom_versions].keys).uniq.each do |version|
           version = icon_versions[version]
           composed_path = File.join(base_path, version[:filename])
           output_path = File.join(options[:root_dir], options[:output_dir], version[:filename])
-        
+
           created = false
           # check for self composed icon file
           if File.exist?(composed_path)
@@ -51,13 +52,13 @@ module FaviconMaker
             image.write output_path
             created = true
           end
-        
+
           if block_given? && created
             yield output_path
           end
         end
       end
-      
+
     end
   end
 end

--- a/spec/favicon_maker_spec.rb
+++ b/spec/favicon_maker_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 describe FaviconMaker, '#create_versions' do
-  
+
   before(:all) do
     @versions = []
     options = {
-      :versions => [:apple_114, :apple_57, :apple, :fav_png, :fav_ico],
+      :versions => [:apple_144, :apple_114, :apple_57, :apple, :fav_png, :fav_ico],
       :custom_versions => {:apple_extreme_retina => {:filename => "apple-touch-icon-228x228-precomposed.png", :dimensions => "228x228", :format => "png"}},
       :root_dir => File.join(Dir.pwd, "spec"),
       :input_dir => "support",
@@ -12,25 +12,25 @@ describe FaviconMaker, '#create_versions' do
       :output_dir => "generated",
       :copy => true
     }
-    
+
     @generated_dir = File.join(options[:root_dir], options[:output_dir])
     Dir.mkdir(@generated_dir)
-    
+
     FaviconMaker::Generator.create_versions(options) do |filepath|
       @versions << filepath
     end
   end
-  
-  it "creates 6 different versions" do
-    @versions.size.should eql(6)
+
+  it "creates 7 different versions" do
+    @versions.size.should eql(7)
   end
 
-  it "creates 6 files" do
+  it "creates 7 files" do
     @versions.each do |file|
       File.exists?(file).should be_true
     end
   end
-  
+
   after(:all) do
     @versions.each do |file|
       File.delete(file)


### PR DESCRIPTION
http://mathiasbynens.be/notes/touch-icons

According to this, the iPad retina favicon size is 144x144 named 'apple-touch-icon-144x144-precomposed.png'.
