### PR TITLE
retain transparency

### DIFF
--- a/lib/favicon_maker/generator.rb
+++ b/lib/favicon_maker/generator.rb
@@ -50,7 +50,7 @@ module FaviconMaker
             image.define "png:include-chunk=none,trns,gama"
             image.resize version[:dimensions]
             image.format version[:format]
-            image.flatten if version[:format] == 'ico'
+            image.colorspace 'RGB'
             image.write output_path
             build_mode = :generated
           end


### PR DESCRIPTION
Option "flatten" removes transparency from generated images.
http://www.imagemagick.org/script/command-line-options.php#layers

And we can dispose of uniform color bug with "colorspace" option
http://stackoverflow.com/questions/13273609/imagemagick-changes-colors-when-converting-pdf-to-images
