### PR TITLE
Add 120 x 120 size to default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In order to integrate the FaviconMaker effortless into your [Middleman](https://
 Uses the following defaults:
 
     options = {
-      :versions => [:apple_144, :apple_114, :apple_72, :apple_57, :apple_pre, :apple, :fav_png, :fav_ico],
+      :versions => [:apple_144, :apple_120, :apple_114, :apple_72, :apple_57, :apple_pre, :apple, :fav_png, :fav_ico],
       :custom_versions => {},
       :root_dir => File.dirname(__FILE__),
       :input_dir => "favicons",
@@ -66,7 +66,7 @@ Uses the following defaults:
 (untested attempted Rails integration, using all available options. Could be used in a Rake task or Capistrano recipe)
 
     options = {
-      :versions => [:apple_144, :apple_114, :apple_57, :apple, :fav_png, :fav_ico],
+      :versions => [:apple_144, :apple_120, :apple_114, :apple_57, :apple, :fav_png, :fav_ico],
       :custom_versions => {:apple_extreme_retina => {:filename => "apple-touch-icon-228x228-precomposed.png", :dimensions => "228x228", :format => "png"}},
       :root_dir => Rails.root,
       :input_dir => File.join("app", "assets", "public"),

--- a/lib/favicon_maker/generator.rb
+++ b/lib/favicon_maker/generator.rb
@@ -6,6 +6,7 @@ module FaviconMaker
 
     ICON_VERSIONS = {
       :apple_144 => {:filename => "apple-touch-icon-144x144-precomposed.png", :sizes => "144x144", :format => "png"},
+      :apple_120 => {:filename => "apple-touch-icon-120x120-precomposed.png", :sizes => "120x120", :format => "png"},
       :apple_114 => {:filename => "apple-touch-icon-114x114-precomposed.png", :sizes => "114x114", :format => "png"},
       :apple_72 => {:filename => "apple-touch-icon-72x72-precomposed.png", :sizes => "72x72", :format => "png"},
       :apple_57 => {:filename => "apple-touch-icon-57x57-precomposed.png", :sizes => "57x57", :format => "png"},

--- a/spec/favicon_maker_spec.rb
+++ b/spec/favicon_maker_spec.rb
@@ -5,7 +5,7 @@ describe FaviconMaker, '#create_versions' do
     @multi_versions = []
     @uni_versions = []
     @options = {
-      :versions => [:apple_144, :apple_114, :apple_72, :apple_57, :apple, :fav_png, :fav_ico],
+      :versions => [:apple_144, :apple_120, :apple_114, :apple_72, :apple_57, :apple, :fav_png, :fav_ico],
       :custom_versions => {:apple_extreme_retina => {:filename => "apple-touch-icon-228x228-precomposed.png", :sizes => "228x228", :format => "png"}},
       :root_dir => File.join(Dir.pwd, "spec"),
       :input_dir => "support",
@@ -40,8 +40,8 @@ describe FaviconMaker, '#create_versions' do
       end
     end
 
-    it "creates 8 different versions" do
-      @multi_versions.size.should eql(8)
+    it "creates 9 different versions" do
+      @multi_versions.size.should eql(9)
     end
 
     it "creates files for versions" do
@@ -75,8 +75,8 @@ describe FaviconMaker, '#create_versions' do
       end
     end
 
-    it "creates 8 different versions" do
-      @uni_versions.size.should eql(8)
+    it "creates 9 different versions" do
+      @uni_versions.size.should eql(9)
     end
 
     it "creates files for versions" do


### PR DESCRIPTION
Mathias Bynens' [touch icons post](http://mathiasbynens.be/notes/touch-icons#sizes) was updated a while ago with the following note:

> Update (June 2013): As of iOS 7, the recommended touch icon size for Retina-display iPhones went up from 114 × 114 pixels to 120 × 120 pixels. This post has been updated to reflect that.

Looks to be a relatively straightforward change so I went straight in for a pull request. The recommended code snippet keeps the 114 x 114 size alongside the new 120 x 120 size, so I've just added the new size, bumped test counts in the gemspec and amended the README.
