### PR TITLE
escaped convert command to allow for pathnames with spaces

### DIFF
--- a/lib/favicon_maker/generator.rb
+++ b/lib/favicon_maker/generator.rb
@@ -72,12 +72,12 @@ module FaviconMaker
               image.colorspace colorspace_conv.last
               image.write output_file
             when :ico
-              ico_cmd = "convert #{input_file} -colorspace #{colorspace_conv.first} "
+              ico_cmd = "convert \"#{input_file}\" -colorspace #{colorspace_conv.first} "
               escapes = "\\" unless is_windows
               sizes.split(',').sort_by{|s| s.split('x')[0].to_i}.each do |size|
                 ico_cmd << "#{escapes}( -clone 0 -colors 256 -resize #{size} #{escapes}) "
               end
-              ico_cmd << "-delete 0 -colors 256 -colorspace #{colorspace_conv.last} #{File.join(output_path, version[:filename])}"
+              ico_cmd << "-delete 0 -colors 256 -colorspace #{colorspace_conv.last} \"#{File.join(output_path, version[:filename])}\""
               puts `#{ico_cmd}`
             end
             build_mode = :generated


### PR DESCRIPTION
Fixed a bug where the build command would throw an error when generating .ico files on paths with spaces. The changes insert " characters around the path sent to convert.
