### PR TITLE
Add support for absolute output paths & fix colour bug

### DIFF
--- a/lib/favicon_maker/generator.rb
+++ b/lib/favicon_maker/generator.rb
@@ -80,9 +80,9 @@ module FaviconMaker
               ico_cmd = "convert \"#{input_file}\" -colorspace #{colorspace_conv.first} "
               escapes = "\\" unless is_windows
               sizes.split(',').sort_by{|s| s.split('x')[0].to_i}.each do |size|
-                ico_cmd << "#{escapes}( -clone 0 -colors 256 -resize #{size} #{escapes}) "
+                ico_cmd << "#{escapes}( -clone 0 -resize #{size} #{escapes}) "
               end
-              ico_cmd << "-delete 0 -colors 256 -colorspace #{colorspace_conv.last} \"#{File.join(output_path, version[:filename])}\""
+              ico_cmd << "-delete 0 -colorspace #{colorspace_conv.last} \"#{File.join(output_path, version[:filename])}\""
               puts `#{ico_cmd}`
             end
             build_mode = :generated

--- a/lib/favicon_maker/generator.rb
+++ b/lib/favicon_maker/generator.rb
@@ -53,7 +53,7 @@ module FaviconMaker
           version = icon_versions[version]
           sizes = version[:dimensions] || version[:sizes]
           composed_path = File.join(base_path, version[:filename])
-          output_path = if Pathname.new(options[:root_dir]).absolute?
+          output_path = if Pathname.new(options[:output_dir]).absolute?
             options[:output_dir]
           else
             File.join(options[:root_dir], options[:output_dir])

--- a/lib/favicon_maker/generator.rb
+++ b/lib/favicon_maker/generator.rb
@@ -1,6 +1,7 @@
 module FaviconMaker
   require "mini_magick"
   require 'fileutils'
+  require 'pathname'
 
   class Generator
 
@@ -52,7 +53,11 @@ module FaviconMaker
           version = icon_versions[version]
           sizes = version[:dimensions] || version[:sizes]
           composed_path = File.join(base_path, version[:filename])
-          output_path = File.join(options[:root_dir], options[:output_dir])
+          output_path = if Pathname.new(options[:root_dir]).absolute?
+            options[:output_dir]
+          else
+            File.join(options[:root_dir], options[:output_dir])
+          end
           output_file = File.join(output_path, version[:filename])
 
           build_mode = nil


### PR DESCRIPTION
File.join() only works if you have a relative build path, this is a quick fix for that.
Also removed colour reduction: https://github.com/follmann/middleman-favicon-maker/issues/12#issuecomment-31896170
