### PR TITLE
Fix `extend Forwardable` for Ruby 2.1.0

### DIFF
--- a/lib/favicon_maker/generator.rb
+++ b/lib/favicon_maker/generator.rb
@@ -1,3 +1,4 @@
+require 'forwardable'
 require 'docile'
 
 module FaviconMaker


### PR DESCRIPTION
``` ruby
2.1.0p0 :001 > require 'favicon_maker'
NameError: uninitialized constant FaviconMaker::Generator::Forwardable
    from /Users/leo/.rvm/gems/ruby-2.1.0/gems/favicon_maker-1.1/lib/favicon_maker/generator.rb:12:in `<class:Generator>'
    from /Users/leo/.rvm/gems/ruby-2.1.0/gems/favicon_maker-1.1/lib/favicon_maker/generator.rb:11:in `<module:FaviconMaker>'
    from /Users/leo/.rvm/gems/ruby-2.1.0/gems/favicon_maker-1.1/lib/favicon_maker/generator.rb:3:in `<top (required)>'
    from /Users/leo/.rvm/rubies/ruby-2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/leo/.rvm/rubies/ruby-2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/leo/.rvm/gems/ruby-2.1.0/gems/favicon_maker-1.1/lib/favicon_maker.rb:2:in `<top (required)>'
    from /Users/leo/.rvm/rubies/ruby-2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
    from /Users/leo/.rvm/rubies/ruby-2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
    from /Users/leo/.rvm/rubies/ruby-2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
    from (irb):1
    from /Users/leo/.rvm/rubies/ruby-2.1.0/bin/irb:11:in `<main>'

```
